### PR TITLE
Replace git apply with patch

### DIFF
--- a/rstudio-desktop/PKGBUILD
+++ b/rstudio-desktop/PKGBUILD
@@ -49,8 +49,8 @@ prepare() {
     cd ${srcdir}/${_srcname}
     local JOBS; JOBS="$(grep -oP -- "-j\s*\K[0-9]+" <<< "${MAKEFLAGS}")" || JOBS="1"
     sed "s/@@proc_num@@/${JOBS}/" -i ${srcdir}/cran_multithread.patch
-    git apply -v ${srcdir}/cran_multithread.patch
-    git apply -v ${srcdir}/node_version.patch
+    patch -p1 < ${srcdir}/cran_multithread.patch
+    patch -p1 < ${srcdir}/node_version.patch
 
     msg "Extracting dependencies..."
     cd "${srcdir}/${_srcname}/src/gwt"


### PR DESCRIPTION
Hey, thanks a lot for the AUR package.
Unfortunately I've not been able to install it.
After some manual tinkering with `makepkg` I realized that `git apply` actually just skips both patch files because it searches for them from the root of the git repo instead of the current working directory. The same issue is discussed [here](https://stackoverflow.com/questions/42386491/git-apply-skips-patches). I don't really understand why I had this error and you did not. I have `git version 2.34.0`.
The easiest way to fix it for me was to just not use `git` for that and replace it with `patch`.
I confirmed that it builds and installs normally after that.