### PR TITLE
Add Pandoc Arch Independent Symlink

### DIFF
--- a/quarto-cli-pre-release/PKGBUILD
+++ b/quarto-cli-pre-release/PKGBUILD
@@ -83,6 +83,7 @@ package() {
   mkdir -p package/pkg-working/bin/tools/${arch}/deno_dom
   cp "${srcdir}/deno-dom-${_denodomver}/target/release/libplugin.so" "${srcdir}/${_pkgbasename}-${pkgver}/package/pkg-working/bin/tools/${arch}/deno_dom"
   ln -sfT /usr/bin/pandoc package/pkg-working/bin/tools/${arch}/pandoc
+  ln -sfT package/pkg-working/bin/tools/pandoc package/pkg-working/bin/tools/${arch}/pandoc
   ln -sfT /usr/bin/deno package/pkg-working/bin/tools/${arch}/deno
   ln -sfT /usr/bin/sass package/pkg-working/bin/tools/${arch}/dart-sass/sass
   ln -sfT /usr/bin/esbuild package/pkg-working/bin/tools/${arch}/esbuild


### PR DESCRIPTION
Thanks for your work supporting Quarto on Arch! I'm not that familiar with Arch Packaging, so if you choose to consider this PR, please review carefully.

Some tools (e.g. VSCode) assume that they can use pandoc directly from the tools directory without being aware of the multi-architecture sub directory. Create a symlink to support this.

(See https://github.com/quarto-dev/quarto/issues/237 for example error)